### PR TITLE
Fix 8 C# translation bugs and catch up to 3 original commits until v3.1.8

### DIFF
--- a/addons/controller_icons/ControllerIcons.cs
+++ b/addons/controller_icons/ControllerIcons.cs
@@ -314,7 +314,7 @@ public partial class ControllerIcons : Node
 		CustomInputActions[input_action] = events;
 	}
 
-	private void refresh()
+	public void Refresh()
 	{
 		// All it takes is to signal icons to refresh paths		
 	#if GODOT4_4_OR_GREATER

--- a/addons/controller_icons/ControllerIcons.cs
+++ b/addons/controller_icons/ControllerIcons.cs
@@ -201,13 +201,13 @@ public partial class ControllerIcons : Node
 		if( Settings?.custom_mapper == null )
 			return;
 
-		GodotObject instance;
+		Variant created;
 		if( Settings.custom_mapper is CSharpScript csharpScript )
-			instance = csharpScript.New();
+			created = csharpScript.New();
 		else
-			instance = Settings.custom_mapper.Call("new").AsGodotObject();
+			created = Settings.custom_mapper.Call("new");
 
-		if( instance is ControllerMapper mapper )
+		if( created.AsGodotObject() is ControllerMapper mapper )
 			Mapper = mapper;
 		else
 			GD.PrintErr("Controller Icons: custom_mapper must extend ControllerMapper.");

--- a/addons/controller_icons/ControllerIcons.cs
+++ b/addons/controller_icons/ControllerIcons.cs
@@ -474,16 +474,17 @@ public partial class ControllerIcons : Node
 			return null;
 
 		List<string> basePaths = new(){
-			Settings.custom_asset_dir + "/",
-			"res://addons/controller_icons/assets/"
+			Settings.custom_asset_dir,
+			"res://addons/controller_icons/assets"
 		};
 
-		foreach( string basePath in basePaths )
+		foreach( string rawBasePath in basePaths )
 		{
+			string basePath = rawBasePath.SimplifyPath();
 			if( string.IsNullOrWhiteSpace(basePath) )
 				continue;
 
-			string dictPath = basePath + path + "." + BaseExtension;
+			string dictPath = basePath.PathJoin( $"{path}.{BaseExtension}" );
 			if( LoadIcon(dictPath) != Error.Ok )
 				continue;
 

--- a/addons/controller_icons/ControllerIcons.cs
+++ b/addons/controller_icons/ControllerIcons.cs
@@ -422,6 +422,7 @@ public partial class ControllerIcons : Node
 				if( LoadIcon( iconPath ) == Error.Ok )
 				{
 					icons.Add( _CachedIcons[iconPath] );
+					break;
 				}
 			}
 		}

--- a/addons/controller_icons/ControllerIcons.cs
+++ b/addons/controller_icons/ControllerIcons.cs
@@ -304,10 +304,9 @@ public partial class ControllerIcons : Node
 				if( f.Target != null && f.Delegate != null ) 
 					f.Call();
 			}
+			_CachedCallables.Clear();
+			_CachedCallablesLock.Unlock();
 		}
-
-		_CachedCallables.Clear();
-		_CachedCallablesLock.Unlock();
 	}
 
 	private void AddCustomInputAction( string input_action , Godot.Collections.Array<InputEvent> events )

--- a/addons/controller_icons/ControllerIcons.cs
+++ b/addons/controller_icons/ControllerIcons.cs
@@ -184,6 +184,7 @@ public partial class ControllerIcons : Node
 		Input.JoyConnectionChanged += OnJoyConnectionChangedEventHandler;
 
 		Settings ??= new();
+		ApplyCustomMapper();
 		Mapper ??= new();
 
 		if( !string.IsNullOrWhiteSpace(Settings.custom_file_extension) )
@@ -193,6 +194,23 @@ public partial class ControllerIcons : Node
 
 		// Wait a frame to give a chance for the app to initialize
 		setLikelyInput = true;
+	}
+
+	private void ApplyCustomMapper()
+	{
+		if( Settings?.custom_mapper == null )
+			return;
+
+		GodotObject instance;
+		if( Settings.custom_mapper is CSharpScript csharpScript )
+			instance = csharpScript.New();
+		else
+			instance = Settings.custom_mapper.Call("new").AsGodotObject();
+
+		if( instance is ControllerMapper mapper )
+			Mapper = mapper;
+		else
+			GD.PrintErr("Controller Icons: custom_mapper must extend ControllerMapper.");
 	}
 	private void OnJoyConnectionChangedEventHandler( long device, bool connected )
 	{

--- a/addons/controller_icons/ControllerSettings.cs
+++ b/addons/controller_icons/ControllerSettings.cs
@@ -53,7 +53,7 @@ public partial class ControllerSettings : Resource
 
 	// Custom generic joystick mapper script
 	[Export]
-	private Script custom_mapper;
+	public Script custom_mapper;
 
 	// Custom icon file extension
 	[Export]

--- a/addons/controller_icons/objects/ControllerIconTexture.cs
+++ b/addons/controller_icons/objects/ControllerIconTexture.cs
@@ -198,7 +198,7 @@ public partial class ControllerIconTexture : Texture2D
 	public string GetTTSString()
 	{
 		if( force_type != EInputType.NONE )
-			return CI.ParsePathToTTS(path, force_type - 1);
+			return CI.ParsePathToTTS(path, force_type);
 		else
 			return CI.ParsePathToTTS(path);
 	}

--- a/addons/controller_icons/objects/ControllerIconTexture.cs
+++ b/addons/controller_icons/objects/ControllerIconTexture.cs
@@ -443,9 +443,9 @@ public partial class ControllerIconTexture : Texture2D
 				);
 
 				DrawText(toCanvasItem, font_position, "+");
+				position += new Vector2(TextSize.X, 0);
 			}
 
-			position += new Vector2(TextSize.X, 0);
 			tex.Draw(toCanvasItem, position, modulate, transpose);
 			position += new Vector2( tex.GetWidth(), 0 );
 		}

--- a/addons/controller_icons/objects/ControllerIconTexture.cs
+++ b/addons/controller_icons/objects/ControllerIconTexture.cs
@@ -630,18 +630,17 @@ public partial class ControllerIconTexture : Texture2D
 		if( Dirty )
 		{
 			if( !IsStitchingTexture )
+			{
 				// FIXME: Function may await, but because this is an internal engine call, we can't do anything about it.
 				// This results in a one-frame white texture being displayed, which is not ideal. Investigate later.
 				StitchTexture();
-				
-			if( IsStitchingTexture )
-				return new Rid(null);
-
+				if( IsStitchingTexture )
+					return new Rid(null);
+			}
 			else
 			{
 				return new Rid(null);
 			}
-				
 		}
 		return Textures.Count > 0 ? Texture3D.GetRid() : new Rid(null);
 	}

--- a/addons/controller_icons/objects/ControllerIconTexture.cs
+++ b/addons/controller_icons/objects/ControllerIconTexture.cs
@@ -616,6 +616,7 @@ public partial class ControllerIconTexture : Texture2D
 		IsStitchingTexture = false;
 
 		Dirty = false;
+		img.GenerateMipmaps();
 		Texture3D = ImageTexture.CreateFromImage(img);
 		EmitChanged();
 	}

--- a/addons/controller_icons/objects/path_selection/InputActionSelector.cs
+++ b/addons/controller_icons/objects/path_selection/InputActionSelector.cs
@@ -149,9 +149,9 @@ public partial class InputActionSelector : SelectorPanel
 		}
 	}
 
-	public override void GrabFocus()
+	public override void GrabFocus( bool hideFocus = false )
 	{
-		nNameFilter.GrabFocus();
+		GrabFocusOn( nNameFilter, hideFocus );
 	}
 
 	private void OnBuiltInActionButtonToggled( bool toggled_on )

--- a/addons/controller_icons/objects/path_selection/SelectorPanel.cs
+++ b/addons/controller_icons/objects/path_selection/SelectorPanel.cs
@@ -6,9 +6,19 @@ using static ControllerIcons;
 
 public partial class SelectorPanel : Panel
 {
-	public new virtual void GrabFocus()
+	private const int Godot46Hex = 0x040600;
+
+	public new virtual void GrabFocus( bool hideFocus = false )
 	{
 		//override me
 	}
 
+	protected static void GrabFocusOn( Control control, bool hideFocus = false )
+	{
+		// UPGRADE: In Godot 4.6, grab_focus has a new internal arg
+		if( Engine.GetVersionInfo()["hex"].AsInt32() >= Godot46Hex )
+			control.Call( "grab_focus", hideFocus );
+		else
+			control.GrabFocus();
+	}
 }

--- a/addons/controller_icons/objects/path_selection/SpecificPathSelector.cs
+++ b/addons/controller_icons/objects/path_selection/SpecificPathSelector.cs
@@ -251,9 +251,9 @@ public partial class SpecificPathSelector : SelectorPanel
 		return "";
 	}
 
-	public override void GrabFocus()
+	public override void GrabFocus( bool hideFocus = false )
 	{
-		NameFilter.GrabFocus();
+		GrabFocusOn( NameFilter, hideFocus );
 	}
 
 	private void OnBaseAssetNamesItemSelected()

--- a/addons/controller_icons/objects/path_selection/SpecificPathSelector.cs
+++ b/addons/controller_icons/objects/path_selection/SpecificPathSelector.cs
@@ -110,7 +110,7 @@ public partial class SpecificPathSelector : SelectorPanel
 		{
 			Category = category;
 			Filtered = true;
-			Path = path.Split("/")[1];
+			Path = path.GetSlice("/", 1);
 
 			Button = new()
 			{
@@ -233,7 +233,7 @@ public partial class SpecificPathSelector : SelectorPanel
 		string filename = path.GetFile();
 		if( ButtonNodes[mapCategory].ContainsKey(filename) ) return;
 
-		string icon_path = (category.Length == 0 ? "" : category ) + "/" + path.GetFile().GetBaseName();
+		string icon_path = (category.Length == 0 ? "" : category + "/") + path.GetFile().GetBaseName();
 		ControllerIcons_Icon icon = new( mapCategory, icon_path);
 
 		ButtonNodes[mapCategory][filename] = icon;

--- a/addons/controller_icons/objects/path_selection/SpecificPathSelector.cs
+++ b/addons/controller_icons/objects/path_selection/SpecificPathSelector.cs
@@ -110,7 +110,8 @@ public partial class SpecificPathSelector : SelectorPanel
 		{
 			Category = category;
 			Filtered = true;
-			Path = path.GetSlice("/", 1);
+			var parts = path.Split('/');
+			Path = parts.Length > 1 ? parts[1] : path;
 
 			Button = new()
 			{


### PR DESCRIPTION
Thanks for the port @jembawls ! 

Because I noticed that there are more recent commits in the GD script version compared to this repo I created an updated version with 11 changes (8 port differences and 3 later changes). I had a look at all of them but they are written by AI and not tested too deeply. Please feel free to do or not do anything with this PR, I just wanted to share the version I'm gonna use here.



---------------------------------------------
AI SLOP BELOW
---------------------------------------------

## Summary

Brings this C# port in line with [rsubtil/controller_icons](https://github.com/rsubtil/controller_icons) through v3.1.8, and fixes several translation bugs that made C# behave differently from the GDScript addon.

**Original catch-up (v3.1.6–v3.1.8)**
- Godot 4.6 `grab_focus(hide_focus)` with a version check so 4.1–4.5 still work
- Generate mipmaps on stitched 3D icon textures
- `ParseEvent` uses `SimplifyPath` + `PathJoin` so empty/odd custom asset dirs do not produce bogus paths

**C# translation fixes**
- Deferred-load mutex: only `Clear`/`Unlock` after a successful `TryLock` (was unlocking every frame)
- Modifier icons: stop after the first successful load so a custom asset dir cannot double Ctrl/Shift/Alt glyphs
- Public `Refresh()` so runtime InputMap changes can rematch icons, as the original docs describe
- Honor `settings.custom_mapper` (script must extend `ControllerMapper`)
- `_GetRid` returns the stitched RID after a synchronous single-icon stitch instead of always returning empty while Dirty
- `_Draw` does not offset the first icon by the `+` width (multi-prompt Sprite2D)
- `GetTTSString` no longer subtracts 1 from `force_type` (`EInputType` already includes `NONE`)
- Specific Path picker: no leading `/` on uncategorized assets (`disconnected` not `/disconnected`)

**Godot 4.7 C# bindings** (verified while testing)
- `CSharpScript.New()` goes through `Variant` then `AsGodotObject()`
- Specific Path labels use `Split('/')` instead of `GetSlice`, which is not on `string` in current bindings

Not included: deprecated `ControllerButton` still hides the whole control when `show_only` mismatches (`Visible = false` vs original `icon = null`). That looks like an intentional C# change.

## Test plan
- [ ] Keyboard/mouse and controller icons still swap on input
- [ ] Runtime remap + `ControllerIcons.CI.Refresh()` updates existing `ControllerIconTexture`s
- [ ] Custom asset dir: modifiers show once; empty custom dir does not break event icons
- [ ] Sprite2D multi-prompt (e.g. Shift+key) spacing matches TextureRect
- [ ] Sprite3D: single icon appears; distant icons are not heavily aliased
- [ ] Path picker: root asset `disconnected` stores `disconnected`; filter focuses on Godot 4.5 and 4.6/4.7
- [ ] Project exports with the plugin enabled (existing `#if TOOLS` behavior unchanged)


Made with [Cursor](https://cursor.com)